### PR TITLE
Feature: add optional canonical url to blog posts

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,7 +3,7 @@ import astroPWA, { type PwaOptions } from '@vite-pwa/astro';
 import astroIcon from 'astro-icon';
 import { defineConfig } from 'astro/config';
 import { readFileSync } from 'node:fs';
-import { assetsCache, externalResourcesCache, pagesCache, scriptsCache } from './src/sw-caching.ts';
+import { assetsCache, externalResourcesCache, pagesCache, scriptsCache } from './src/sw-caching.js';
 
 const manifest: PwaOptions['manifest'] = JSON.parse(readFileSync('./src/manifest.json', {
 	encoding: 'utf8'

--- a/dprint.json
+++ b/dprint.json
@@ -142,11 +142,11 @@
 		"**/.obsidian/**"
 	],
 	"plugins": [
-		"https://plugins.dprint.dev/typescript-0.91.4.wasm",
+		"https://plugins.dprint.dev/typescript-0.93.0.wasm",
 		"https://plugins.dprint.dev/json-0.19.3.wasm",
-		"https://plugins.dprint.dev/g-plane/malva-v0.5.1.wasm",
-		"https://plugins.dprint.dev/g-plane/markup_fmt-v0.11.0.wasm",
-		"https://plugins.dprint.dev/markdown-0.17.1.wasm",
-		"https://plugins.dprint.dev/g-plane/pretty_yaml-v0.4.0.wasm"
+		"https://plugins.dprint.dev/g-plane/malva-v0.10.1.wasm",
+		"https://plugins.dprint.dev/g-plane/markup_fmt-v0.13.1.wasm",
+		"https://plugins.dprint.dev/markdown-0.17.8.wasm",
+		"https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm"
 	]
 }

--- a/src/components/HtmlHead/index.astro
+++ b/src/components/HtmlHead/index.astro
@@ -1,3 +1,108 @@
 ---
+// @ts-expect-error
+import { pwaInfo } from 'virtual:pwa-info';
 
+import defaultSocialImage from '../../assets/icons/logo.svg';
+import printStylesheet from './print.css?url';
+
+interface Props {
+	htmlTitle?: string[],
+	title: string,
+	url: string,
+	canonicalUrl?: string,
+	description: string,
+	tags?: string[],
+	authors?: string[],
+	image?: string,
+	imageAlt?: string,
+	createdAt?: Date,
+	updatedAt?: Date,
+	hasFeed?: boolean
+}
+
+const {
+	htmlTitle, title, url,
+	canonicalUrl,
+	description, tags,
+	authors,
+
+	image, imageAlt,
+
+	createdAt: publishedDate,
+	updatedAt: updatedDate,
+
+	hasFeed = false
+} = Astro.props;
+
+const BLOG_URL = Astro.site?.href;
+const fullUrl = new URL(url, Astro.site).toString();
+
+const socialImageAlt = imageAlt ?? 'Logo for TorontoJS, consisting of a red square with the letters &quot;JS&quot; in black on the left, and a sillouette of the CN Tower seen from the ground up on the right.';
+const socialImage = `${BLOG_URL}${(image ?? defaultSocialImage.src).replace(/^\//iu, '')}`;
 ---
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width,initial-scale=1" />
+
+	<title>{htmlTitle?.join(' | ') ?? title}</title>
+
+	<!-- URLs -->
+	<link rel="canonical" href={canonicalUrl ?? fullUrl} />
+	<link rel="sitemap" href={`${BLOG_URL}sitemap-index.xml`} />
+	{ hasFeed && <link rel="alternate" type="application/rss+xml" href={`${BLOG_URL}feed.xml`} title="TorontoJS Blog" /> }
+
+	<!-- App Metadata -->
+	<link rel="icon" href={`${BLOG_URL}icons/icon.svg`} sizes="any" type="image/svg+xml" />
+	<meta name="theme-color" content="#ee2e24" />
+	<link rel="license" href={`${BLOG_URL}license`} />
+
+	{/* eslint-disable-next-line astro/no-set-html-directive */}
+	{pwaInfo && (<Fragment set:html={pwaInfo.webManifest.linkTag} />)}
+
+	<!-- Social metadata -->
+	<meta property="og:title" name="twitter:title" itemprop="name" content={title} />
+
+	<meta property="og:type" content={hasFeed ? 'article' : 'website'} />
+	<meta name="twitter:card" content={socialImage ? 'summary_large_image' : 'summary'} />
+
+	<meta property="og:locale" itemprop="inLanguage" content="en_US" />
+	<meta property="og:url" itemprop="url" content={fullUrl} />
+
+	<meta property="og:description" name="description" itemprop="abstract" content={description} />
+	<meta name="twitter:description" content={description} />
+
+	<meta property="og:image" name="twitter:image" itemprop="image" content={socialImage} />
+	<meta property="og:image:alt" name="twitter:image:alt" content={socialImageAlt} />
+
+	{authors?.map((author) => (
+		<>
+			<meta property="article:author" name="author" content={author} />
+			<meta name="twitter:creator" content={author} />
+			<!-- TODO: fix to specifically reference to twitter handle -->
+		</>
+	))}
+
+	<meta name="twitter:dnt" content="on" />
+	<meta name="twitter:widgets:csp" content="on" />
+	<meta name="twitter:widgets:autoload" content="off" />
+	<meta name="twitter:widgets:theme" content="dark" />
+
+	<meta name="generator" content={Astro.generator} />
+
+	{tags && (<meta name="keywords" itemprop="keywords" property="article:tag" content={tags.join(', ')} />)}
+	{publishedDate && (<meta property="article:published_time" content={publishedDate.toISOString()} />)}
+	{updatedDate && (<meta property="article:modified_time" content={updatedDate.toISOString()} />)}
+
+	<!-- Changelog -->
+	<link rel="alternate" type="application/rss+xml" href={`${BLOG_URL}changelog.xml`} title="Changelog (Version History)" />
+
+	<!-- Apple icons -->
+	<meta name="apple-mobile-web-app-capable" content="yes" />
+	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+
+	<!-- Print Stylesheet -->
+	<link rel="stylesheet" type="text/css" href={printStylesheet} media="print" />
+
+	<!-- Fonts -->
+	<link href="https://fonts.googleapis.com/css?family=Roboto:300,700|Inter:400,700" rel="stylesheet" />
+</head>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,7 +1,7 @@
 import { defineCollection } from 'astro:content';
 
-import { authorsSchema } from '../schemas/authors.ts';
-import { blogSchema } from '../schemas/blog.ts';
+import { authorsSchema } from '../schemas/authors.js';
+import { blogSchema } from '../schemas/blog.js';
 
 const blogCollection = defineCollection({
 	type: 'content',

--- a/src/layouts/Base/index.astro
+++ b/src/layouts/Base/index.astro
@@ -9,6 +9,7 @@ interface Props {
 	title: string;
 	htmlTitle?: string[];
 	url: string;
+	canonicalUrl?: string;
 	description: string;
 	authors?: string[];
 	tags?: string[];
@@ -26,6 +27,7 @@ const {
 	description,
 	authors,
 	url,
+	canonicalUrl,
 	tags,
 	image,
 	imageAlt,
@@ -41,6 +43,7 @@ const {
 		{htmlTitle}
 		{title}
 		{url}
+		{canonicalUrl}
 		{description}
 		{authors}
 		{tags}

--- a/src/layouts/BlogPost/index.astro
+++ b/src/layouts/BlogPost/index.astro
@@ -12,6 +12,7 @@ import './styles.css';
 interface Props {
 	title: string;
 	summary: string;
+	canonicalUrl?: string;
 	authors: string[];
 	image?: ImageMetadata;
 	imageAlt?: string;
@@ -32,6 +33,7 @@ const {
 	url,
 	title,
 	summary,
+	canonicalUrl,
 	authors,
 	image,
 	imageAlt,
@@ -58,6 +60,7 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 	{authors}
 	{tags}
 	url={postUrl}
+	canonicalUrl={canonicalUrl}
 	image={image?.src}
 	{imageAlt}
 	{createdAt}

--- a/src/pages/[year]/[...page].astro
+++ b/src/pages/[year]/[...page].astro
@@ -3,7 +3,7 @@ import type { GetStaticPaths, InferGetStaticPropsType, PaginateFunction } from '
 
 import BlogPostsLayout from '../../layouts/BlogPosts.astro';
 
-import { listPostPagesByYear, MAX_POSTS_PER_PAGE } from '../../utils/post.ts';
+import { listPostPagesByYear, MAX_POSTS_PER_PAGE } from '../../utils/post.js';
 
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;

--- a/src/pages/[year]/[month]/[...page].astro
+++ b/src/pages/[year]/[month]/[...page].astro
@@ -3,7 +3,7 @@ import type { GetStaticPaths, InferGetStaticPropsType, PaginateFunction } from '
 
 import BlogPostsLayout from '../../../layouts/BlogPosts.astro';
 
-import { listPostsPagesByMonth, MAX_POSTS_PER_PAGE } from '../../../utils/post.ts';
+import { listPostsPagesByMonth, MAX_POSTS_PER_PAGE } from '../../../utils/post.js';
 
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;

--- a/src/pages/[year]/[month]/[slug].astro
+++ b/src/pages/[year]/[month]/[slug].astro
@@ -2,7 +2,7 @@
 import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
 
 import BlogPostLayout from '../../../layouts/BlogPost/index.astro';
-import { listAllPosts } from '../../../utils/post.ts';
+import { listAllPosts } from '../../../utils/post.js';
 
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;

--- a/src/pages/[year]/[month]/[slug].astro
+++ b/src/pages/[year]/[month]/[slug].astro
@@ -24,6 +24,7 @@ const {
 	data: {
 		title,
 		summary,
+		canonicalUrl,
 		image,
 		imageAlt,
 		createdAt,
@@ -40,20 +41,21 @@ const {
 const { Content } = await render();
 ---
 <BlogPostLayout
-	{url}
-	{title}
-	{summary}
-	{authors}
-	{image}
-	{imageAlt}
-	{createdAt}
-	{updatedAt}
-	{updates}
-	{tags}
-	{readingTime}
-	{wordCount}
-	{letterCount}
-	{relatedPosts}
+	url={url}
+	title={title}
+	summary={summary}
+	canonicalUrl={canonicalUrl}
+	authors={authors}
+	image={image}
+	imageAlt={imageAlt}
+	createdAt={createdAt}
+	updatedAt={updatedAt}
+	updates={updates}
+	tags={tags}
+	readingTime={readingTime}
+	wordCount={wordCount}
+	letterCount={letterCount}
+	relatedPosts={relatedPosts}
 >
 	<Content />
 </BlogPostLayout>

--- a/src/schemas/blog.ts
+++ b/src/schemas/blog.ts
@@ -27,5 +27,6 @@ export const blogSchema = ({ image }: SchemaContext) =>
 				'The date of the update. As a parseable date string, without quotes. Examples: "2024-01-01", "2024-01-01 00:00:00", "2024-01-01T00:00:00-04:00", "2024-01-01T00:00:00Z".'
 			),
 			changes: zod.string().describe('A summary of the changes in this update.')
-		})).optional().describe('The list of updates this post had. It is a list of objects with the keys "date" and "changes".')
+		})).optional().describe('The list of updates this post had. It is a list of objects with the keys "date" and "changes".'),
+		canonicalUrl: zod.string().optional().describe('The original URL for the post, used when cross posting on Toronto JS blog.')
 	});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"include": ["globals.d.ts", "astro.config.ts", "src/**/*.ts", "src/**/*.d.ts", ".astro/**/*.d.ts"],
+	"include": ["globals.d.ts", "astro.config.ts", "src/**/*.ts", "src/**/*.d.ts", ".astro/**/*.d.ts", "src/env.d.ts"],
 	"exclude": ["node_modules/**/*", "dist/**/*", "src/content/**/*.js"],
 	"compilerOptions": {
 		"allowImportingTsExtensions": true,


### PR DESCRIPTION
Add a way to reference cross-posts via `<link rel="canonical" />`.

This is done by adding the property `canonicalUrl` to the blog post frontmatter.